### PR TITLE
Convert bootstrap from ruby to shell

### DIFF
--- a/spec/acceptance/init_spec.rb
+++ b/spec/acceptance/init_spec.rb
@@ -1,43 +1,12 @@
 # run a test task
 require 'spec_helper_acceptance'
 
-describe 'package task' do
-  #describe 'install', if: pe_install? do
-  #  before(:all) do
-  #    apply_manifest('package { "tmux": ensure => absent, }')
-  #  end
-  #  it 'installs tmux' do
-  #    result = run_task(task_name: 'package', params: 'action=install package=tmux')
-  #    expect_multiple_regexes(result: result, regexes: [%r{status : installed}, %r{version : 1.\d}, %r{Job completed. 1/1 nodes succeeded}])
-  #  end
-  #  it 'returns the version of tmux' do
-  #    result = run_task(task_name: 'package', params: 'action=status package=tmux')
-  #    expect_multiple_regexes(result: result, regexes: [%r{status : up to date}, %r{Job completed. 1/1 nodes succeeded}])
-  #  end
-  #end
-  #describe 'uninstall', if: pe_install? do
-  #  before(:all) do
-  #    apply_manifest('package { "tmux": ensure => "present", }')
-  #  end
-
-  #  it 'uninstalls tmux' do
-  #    result = run_task(task_name: 'package', params: 'action=uninstall package=tmux')
-  #    expect_multiple_regexes(result: result, regexes: [%r{status : uninstalled}, %r{Job completed. 1/1 nodes succeeded}])
-  #  end
-  #  it 'status' do
-  #    result = run_task(task_name: 'package', params: 'action=status package=tmux')
-  #    expect_multiple_regexes(result: result, regexes: [%r{status : failure}, %r{error : Tried to get latest on a missing package}])
-  #  end
-  #end
-  #describe 'upgrade', if: (fact('operatingsystem') == 'CentOS' && pe_install?) do
-  #  it 'upgrade httpd to a specific version' do
-  #    result = run_task(task_name: 'package', params: 'action=upgrade package=httpd version=2.4.6-45.el7.centos')
-  #    expect_multiple_regexes(result: result, regexes: [%r{version : 2.4.6-45.el7.centos}, %r{Job completed. 1/1 nodes succeeded}])
-  #  end
-
-  #  it 'upgrade httpd' do
-  #    result = run_task(task_name: 'package', params: 'action=upgrade package=httpd')
-  #    expect_multiple_regexes(result: result, regexes: [%r{version : 2.4.6-45.el7.centos.4}, %r{old_version : 2.4.6-45.el7.centos}, %r{Job completed. 1/1 nodes succeeded}])
-  #  end
-  #end
+describe 'bootstrap task' do
+  describe 'install', if: pe_install? do
+    it 'installs the agent' do
+      fingerprint = on(master, "puppet cert list #{master.hostname}").stdout.match(%r{[0-9A-F:]{95}})[0]
+      result = run_bolt_task(task_name: 'bootstrap', params: "master=#{master.hostname} ca_fingerprint=#{fingerprint}")
+      expect_multiple_regexes(result: result, regexes: [%r{status : installed}, %r{version : 1.\d}, %r{Job completed. 1/1 nodes succeeded}])
+    end
+  end
 end

--- a/spec/spec_helper_acceptance.rb
+++ b/spec/spec_helper_acceptance.rb
@@ -7,12 +7,11 @@ def install_bolt_on(hosts)
   on(hosts, "/opt/puppetlabs/puppet/bin/gem install --source http://rubygems.delivery.puppetlabs.net bolt -v '> 0.0.1'", acceptable_exit_codes: [0, 1]).stdout
 end
 
-#XXX only install on master
-run_puppet_install_helper
-install_ca_certs unless ENV['PUPPET_INSTALL_TYPE'] =~ %r{pe}i
-install_bolt_on(hosts) unless ENV['PUPPET_INSTALL_TYPE'] =~ %r{pe}i
-install_module_on(hosts)
-install_module_dependencies_on(hosts)
+run_puppet_install_helper_on(master)
+install_ca_certs_on(master) unless ENV['PUPPET_INSTALL_TYPE'] =~ %r{pe}i
+install_bolt_on(master)
+install_module_on(master)
+install_module_dependencies_on([master])
 
 UNSUPPORTED_PLATFORMS = %w[Windows Solaris AIX].freeze
 

--- a/tasks/init
+++ b/tasks/init
@@ -1,45 +1,42 @@
-#!/opt/puppetlabs/puppet/bin/ruby
+#!/bin/sh
 
-require 'json'
-
-def validate(value)
-  if value && value.include?("'")
-    $stderr.puts "Single-quote is not allowed in arguments"
+set -x 
+function validate() {
+  if $(echo $1 | grep \' > /dev/null) ; then
+    echo "Single-quote is not allowed in arguments" > /dev/stderr
     exit 1
-  end
-end
+  fi
+}
 
-args = JSON.parse(STDIN.read)
-master = args['master']
-ca_fingerprint = args['ca-fingerprint']
-certname = args['certname']
-alt_names = args['dns-alt-names']
+master=$PT_master
+ca_fingerprint=$PT_ca_fingerprint
+certname=$PT_certname
+alt_names=$PT_dns_alt_names
 
-validate(certname)
-validate(alt_names)
+validate $certname
+validate $alt_names
 
-agent_args = ''
-agent_args << "agent:certname='#{certname}' " if certname
-agent_args << "agent:dns_alt_names='#{alt_names}' " if alt_names
+if [ -n "${certname?}" ] ; then
+  certname_arg="agent:certname='${certname}' "
+fi
+if [ -n "${alt_names?}" ] ; then
+  alt_names_arg="agent:dns_alt_names='${alt_names}' "
+fi
 
-install_script = <<-SCRIPT
 set -e
 
-[ -f /etc/puppetlabs/puppet/ssl/certs/ca.pem ] || curl -sko /etc/puppetlabs/puppet/ssl/certs/ca.pem https://#{master}:8140/puppet-ca/v1/certificates/ca.pem
+[ -d /etc/puppetlabs/puppet/ssl/certs ] || mkdir -p /etc/puppetlabs/puppet/ssl/certs
+#[ -f /etc/puppetlabs/puppet/ssl/certs/ca.pem ] || echo -n | openssl s_client -connect ${master}:8140 | sed -ne '/-BEGIN CERTIFICATE-/,/-END CERTIFICATE-/p' > /etc/puppetlabs/puppet/ssl/certs/ca.pem
+echo -n | openssl s_client -connect ${master}:8140 | sed -ne '/-BEGIN CERTIFICATE-/,/-END CERTIFICATE-/p' > /etc/puppetlabs/puppet/ssl/certs/ca.pem
 
-expected_fingerprint="#{ca_fingerprint.to_s.upcase}"
+expected_fingerprint="$(echo ${ca_fingerprint?} | tr '[:lower:]' '[:upper:]')"
 if [ -n "${expected_fingerprint?}" ]; then
-  actual_fingerprint="$(openssl x509 -fingerprint -in /etc/puppetlabs/puppet/ssl/certs/ca.pem -noout | cut -f2 -d=)"
+  actual_fingerprint="$(openssl x509 -fingerprint -in /etc/puppetlabs/puppet/ssl/certs/ca.pem -noout -sha256 | cut -f2 -d=)"
   if [ "${actual_fingerprint?}" != "${expected_fingerprint}" ]; then
     echo "CA fingerprint ${actual_fingerprint?} does not match expected fingerprint ${expected_fingerprint?}"
     exit 1
   fi
 fi
 
-curl -s --cacert /etc/puppetlabs/puppet/ssl/certs/ca.pem https://#{master}:8140/packages/current/install.bash | bash -s #{agent_args}
-SCRIPT
-
-system(install_script)
-
-exit $?.exitstatus
+curl -s --cacert /etc/puppetlabs/puppet/ssl/certs/ca.pem https://${master}:8140/packages/current/install.bash | bash -s ${certname_arg}${alt_names_arg}
 

--- a/tasks/init.json
+++ b/tasks/init.json
@@ -1,13 +1,13 @@
 {
   "summary": "Bootstrap a node with puppet-agent",
   "supports_noop": true,
-  "input_method": "stdin",
+  "input_method": "environment",
   "parameters": {
     "master": {
       "description": "The master from which the puppet-agent should be bootstrapped.",
       "type": "String"
     },
-    "ca-fingerprint": {
+    "ca_fingerprint": {
       "description": "The expected CA fingerprint of the master.",
       "type": "String"
     },
@@ -15,7 +15,7 @@
       "description": "The certname with which the node should be bootstrapped.",
       "type": "Optional[String]"
     },
-    "dns-alt-names": {
+    "dns_alt_names": {
       "description": "The DNS alt names with which the agent certificate should be generated.",
       "type": "Optional[String]"
     }


### PR DESCRIPTION
- Use bolt instead of puppet task (because bolt has ssh transport).
- No ruby on target host, so rewrite in shell.
- hypens don't work for task parameter names.