### PR TITLE
Add tags and text to improve searchability

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -2,9 +2,10 @@
   "name": "puppetlabs-bootstrap",
   "version": "0.3.0",
   "author": "puppet",
-  "summary": "Tasks that bootstrap puppet-agent",
+  "summary": "Tasks that bootstrap/install Puppet Enterprise agents on Linux and Windows",
   "license": "Apache-2.0",
   "source": "https://github.com/puppetlabs/puppetlabs-bootstrap",
+  "tags": ["puppet","enterprise","agent","install"],
   "dependencies": [
 
   ],


### PR DESCRIPTION
Currently, this module does not appear in the results of a search for "puppet agent install" on the forge.  This small update adds "tags" and updates the description to improve searchability.