### PR TITLE
Update requirements

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,11 +12,13 @@
 
 ## Description
 
-This module provides the bootstrap task. This allows you to install puppet-agent on un-puppeted hosts via the ssh transport.
+This module provides the bootstrap task. This allows you to install Puppet agents on un-puppeted hosts via the ssh or winrm transports.
 
 ## Requirements
 
-This module requires both the `bolt` task runner and a Puppet Enterprise 2017.3 or later master to be installed on the machine from which you are running bolt commands (the controller node). Machines receiving task requests must have bash for now. (See [Limitations](#limitations) for more info.)
+This module requires both the `bolt` gem on the machine from which you are running bolt commands (the controller node), and a Puppet Enterprise 2017.3 or later master hosting agent repositories.
+
+Linux machines receiving task requests must have bash for now.  Windows machines must have PowerShell. (See [Limitations](#limitations) for more info.)
 
 ## Usage
 

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ Linux machines receiving task requests must have bash for now.  Windows machines
 
 ## Usage
 
-To run the bootstrap task, use the bolt command, specifying the PE master from which the puppet-agent package should be installed and to which the agent should submit its certificate for signing.
+To run the bootstrap task, use the bolt command, specifying the PE master from which the Puppet agent package should be installed and to which the agent should submit its certificate for signing.
 
 #### Example: Basic usage
 
@@ -38,12 +38,12 @@ Optionally to validate the connection during the bootstrap process, specify the 
 
 #### Example: Specify a custom certname
 
-Optionally to install the puppet-agent with a certname other than the fqdn of the target node, specify the custom certname:
+Optionally to install the Puppet agent with a certname other than the fqdn of the target node, specify the custom certname:
 `bolt task run bootstrap::linux master=<master's fqdn> certname=<custom certname> --nodes x,y,z --modulepath /path/to/modules`
 
 #### Example: Specify custom dns alt names
 
-Optionally to install the puppet-agent with custom dns alt names, specify the custom dns alt names:
+Optionally to install the Puppet agent with custom dns alt names, specify the custom dns alt names:
 `bolt task run bootstrap::linux master=<master's fqdn> dns_alt_names=<comma-separated list of alt names for the node> --nodes x,y,z --modulepath /path/to/modules`
 (see [Compile master installation](https://docs.puppet.com/pe/latest/install_multimaster.html) documentation for more info).
 
@@ -51,11 +51,11 @@ You can also run tasks in the PE console. See PE task documentation for complete
 
 #### Example: Specify a custom_attribute
 
-Optionally to install the puppet-agent and adding a setting to puppet.conf and including it in the custom_attributes section of csr_attributes.yaml: `bolt task run bootstrap master=<master's fqdn> custom_attribute=key=value --nodes x,y,z --modulepath /path/to/modules`
+Optionally to install the Puppet agent and adding a setting to puppet.conf and including it in the custom_attributes section of csr_attributes.yaml: `bolt task run bootstrap master=<master's fqdn> custom_attribute=key=value --nodes x,y,z --modulepath /path/to/modules`
 
 #### Example: Specify a extension_request
 
-Optionally to install the puppet-agent and adding a setting to puppet.conf and including it in the extension_requests section of csr_attributes.yaml: `bolt task run bootstrap master=<master's fqdn> extension_request=key=value --nodes x,y,z --modulepath /path/to/modules`
+Optionally to install the Puppet agent and adding a setting to puppet.conf and including it in the extension_requests section of csr_attributes.yaml: `bolt task run bootstrap master=<master's fqdn> extension_request=key=value --nodes x,y,z --modulepath /path/to/modules`
 
 ## Reference
 


### PR DESCRIPTION
Previously, the description and requirements sections applied to Linux, but not to Windows target nodes.  The first commit adds text to address Windows users.

Additionally, the text referred to "puppet-agent" which was the name of the version 4 Linux package.  The second commit updates this with a more generic "Puppet agent" to suit pretty much any version of Puppet.