### PR TITLE
MODULES-7511 ability to insert environment name during agent install

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,11 @@ Optionally to validate the connection during the bootstrap process, specify the 
 Optionally to install the puppet-agent with a certname other than the fqdn of the target node, specify the custom certname:
 `bolt task run bootstrap::linux master=<master's fqdn> certname=<custom certname> --nodes x,y,z --modulepath /path/to/modules`
 
+#### Example: Specify the environment
+
+Optionally to install the puppet-agent with a specific environment other than the default environment `production`, specify the custom environment:
+`bolt task run bootstrap::linux master=<master's fqdn> environment=<custom environment> --nodes x,y,z --modulepath /path/to/modules`
+
 #### Example: Specify custom dns alt names
 
 Optionally to install the puppet-agent with custom dns alt names, specify the custom dns alt names:

--- a/tasks/linux.json
+++ b/tasks/linux.json
@@ -14,6 +14,10 @@
       "description": "The certname with which the node should be bootstrapped",
       "type": "Optional[String]"
     },
+    "environment": {
+      "description": "The environment in which the node should be bootstrapped",
+      "type": "Optional[String]"
+    },
     "dns_alt_names": {
       "description": "The DNS alt names with which the agent certificate should be generated",
       "type": "Optional[String]"

--- a/tasks/linux.sh
+++ b/tasks/linux.sh
@@ -10,15 +10,20 @@ validate() {
 master="$PT_master"
 cacert_content="$PT_cacert_content"
 certname="$PT_certname"
+environment="$PT_environment"
 alt_names="$PT_dns_alt_names"
 custom_attribute="$PT_custom_attribute"
 extension_request="$PT_extension_request"
 
 validate $certname
+validate $environment
 validate $alt_names
 
 if [ -n "${certname?}" ] ; then
   certname_arg="agent:certname='${certname}' "
+fi
+if [ -n "${environment?}" ] ; then
+  alt_names_arg="agent:environment='${environment}' "
 fi
 if [ -n "${alt_names?}" ] ; then
   alt_names_arg="agent:dns_alt_names='${alt_names}' "


### PR DESCRIPTION
Need to be able to insert a custom environment name during agent install on linux agents