### PR TITLE
(MODULES-7511) Add Environment option for Windows

### DIFF
--- a/tasks/windows.json
+++ b/tasks/windows.json
@@ -14,6 +14,10 @@
       "description": "The certname with which the node should be bootstrapped",
       "type": "Optional[String]"
     },
+    "environment": {
+      "description": "The environment in which the node should be bootstrapped",
+      "type": "Optional[String]"
+    },
     "dns_alt_names": {
       "description": "The DNS alt names with which the agent certificate should be generated",
       "type": "Optional[String]"

--- a/tasks/windows.ps1
+++ b/tasks/windows.ps1
@@ -25,6 +25,10 @@ Param(
   $DNS_Alt_Names,
 
   [Parameter(Mandatory = $False)]
+  [String]
+  $Environment,
+
+  [Parameter(Mandatory = $False)]
   [ValidateScript({ $_ -match '\w+=\w+' })]
   [String[]]
   $Custom_Attribute,
@@ -194,6 +198,9 @@ try
   }
   if ($PSBoundParameters.ContainsKey('Extension_Request')) {
     $options.ExtraConfig += (New-OptionsHash 'extension_requests' $Extension_Request)
+  }
+  if ($SBoundParameters.ContainsKey('Environment')) {
+    $options.ExtraConfig += @{ 'agent:environment' = "'$Environment'" }
   }
 
   $installerOutput = Invoke-SimplifiedInstaller @options


### PR DESCRIPTION
Adds an option to specify the environment when bootstrapping Windows
nodes.