### PR TITLE
(MODULES-7838) Windows task contains typo which causes failure.

### DIFF
--- a/tasks/windows.ps1
+++ b/tasks/windows.ps1
@@ -199,7 +199,7 @@ try
   if ($PSBoundParameters.ContainsKey('Extension_Request')) {
     $options.ExtraConfig += (New-OptionsHash 'extension_requests' $Extension_Request)
   }
-  if ($SBoundParameters.ContainsKey('Environment')) {
+  if ($PSBoundParameters.ContainsKey('Environment')) {
     $options.ExtraConfig += @{ 'agent:environment' = "'$Environment'" }
   }
 


### PR DESCRIPTION
The command should be $*P*SBoundParameters not $SBoundParameters.
This adds back the missing 'P'

## Testing
Use bolt to verify the task works as expected.

1) Create a Windows Machine
2) Use Bolt to execute the task
```
bolt task run bootstrap::windows --modulepath /task-modules --params '{ "master" : "my.puppet.master.com" }' --transport winrm -u Admin -p ***** --no-ssl --no-ssl-verify -n <windows IP>
```
3) Verify that the puppet agent has been installed on the target host.