### PR TITLE
(MODULES-6989) Multiple extension_requests/custom_attributes Linux task

### DIFF
--- a/tasks/linux.json
+++ b/tasks/linux.json
@@ -24,11 +24,11 @@
     },
     "custom_attribute": {
       "description": "This setting is added to puppet.conf and included in the custom_attributes section of csr_attributes.yaml",
-      "type": "Optional[Pattern[/\\w+=\\w+/]]"
+      "type": "Optional[Array[Pattern[/\\w+=\\w+/]]]"
     },
     "extension_request": {
       "description": "This setting is added to puppet.conf and included in the extension_requests section of csr_attributes.yaml",
-      "type": "Optional[Pattern[/\\w+=\\w+/]]"
+      "type": "Optional[Array[Pattern[/\\w+=\\w+/]]]"
     }
   }
 }

--- a/tasks/linux.sh
+++ b/tasks/linux.sh
@@ -1,10 +1,27 @@
-#!/bin/sh
+#!/bin/bash
 
 validate() {
   if $(echo $1 | grep \' > /dev/null) ; then
     echo "Single-quote is not allowed in arguments" > /dev/stderr
     exit 1
   fi
+}
+
+convert_array_string() {
+  array_string=$2
+  array_string=${array_string// /}
+  array_string=${array_string//,/ }
+
+  array_string=${array_string##[}
+  array_string=${array_string%]}
+
+  eval array=($array_string)
+
+  for item in "${array[@]}"
+  do
+    result="${result} $1:$item "
+  done
+  echo $result
 }
 
 master="$PT_master"
@@ -29,10 +46,10 @@ if [ -n "${alt_names?}" ] ; then
   alt_names_arg="agent:dns_alt_names='${alt_names}' "
 fi
 if [ -n "${custom_attribute?}" ] ; then
-  custom_attributes_arg="custom_attributes:$custom_attribute "
+  custom_attributes_arg="$(convert_array_string custom_attributes "${custom_attribute}") "
 fi
 if [ -n "${extension_request?}" ] ; then
-  extension_requests_arg="extension_requests:$extension_request "
+  extension_requests_arg="$(convert_array_string extension_requests "${extension_request}") "
 fi
 
 set -e


### PR DESCRIPTION
Tested with the following steps:
1. Retrieve PE master
2. Retrieve non-Puppet node
3. Run the following:
```
$ bolt task run bootstrap::linux --params '{ "master":<master-node>, "environment":"production", "custom_attribute":["a=1","b=2"], "extension_request":["c=3","d=4"]}' --nodes <agent-node> -m <modulepath> --no-host-key-check --run-as root
```
4. Checking csr_attributes.yaml of agent node shows values were added successfully
```
$ root@<agent-node>:~# cat /etc/puppetlabs/puppet/csr_attributes.yaml
---
custom_attributes:
  a: '1'
  b: '2'
extension_requests:
  c: '3'
  d: '4'
```