### PR TITLE
Ensure certnames are *always* lowercase

### DIFF
--- a/tasks/windows.ps1
+++ b/tasks/windows.ps1
@@ -186,7 +186,7 @@ try
 {
   $options = @{
     Master = $Master
-    CertName = ($PSBoundParameters['CertName'], (Get-HostName) -ne $null)[0]
+    CertName = ($PSBoundParameters['CertName'], (Get-HostName) -ne $null)[0].ToLower()
     CACertContent = ($PSBoundParameters['CACertContent'], (Get-CA -Master $Master) -ne $null)[0]
     ExtraConfig = @{}
   }


### PR DESCRIPTION
This is a workaround for PE-25905
Fixes #62