### PR TITLE
(SEN-787) Make linux and windows private

### DIFF
--- a/tasks/init.json
+++ b/tasks/init.json
@@ -1,4 +1,51 @@
 {
+  "description": "Bootstrap a node with puppet-agent",
+  "input_method": "stdin",
+  "parameters": {
+    "master": {
+      "description": "The fqdn of the master from which the puppet-agent should be bootstrapped",
+      "type": "String"
+    },
+    "cacert_content": {
+      "description": "The expected CA certificate content for the master",
+      "type": "Optional[String]"
+    },
+    "certname": {
+      "description": "The certname with which the node should be bootstrapped",
+      "type": "Optional[String]"
+    },
+    "environment": {
+      "description": "The environment in which the node should be bootstrapped",
+      "type": "Optional[String]"
+    },
+    "dns_alt_names": {
+      "description": "The DNS alt names with which the agent certificate should be generated",
+      "type": "Optional[String]"
+    },
+    "custom_attribute": {
+      "description": "This setting is added to puppet.conf and included in the custom_attributes section of csr_attributes.yaml",
+      "type": "Optional[Array[Pattern[/\\w+=\\w+/]]]"
+    },
+    "extension_request": {
+      "description": "This setting is added to puppet.conf and included in the extension_requests section of csr_attributes.yaml",
+      "type": "Optional[Array[Pattern[/\\w+=\\w+/]]]"
+    }
+  },
+  "extensions": {
+    "discovery": {
+      "friendlyName": "Install Puppet agent",
+      "puppetInstall": true,
+      "type": ["host"],
+      "parameters": {
+          "master": {
+              "placeholder": "master.company.net"
+          },
+          "cacert_content": {
+              "placeholder": "-----BEGIN CERTIFICATE---- ... -----END CERTIFICATE-----"
+          }
+      }
+    }
+  },
   "implementations": [
     {"name": "windows.ps1", "requirements": ["powershell"], "input_method": "powershell"},
     {"name": "linux.sh", "requirements": ["shell"], "input_method": "environment"}

--- a/tasks/linux.json
+++ b/tasks/linux.json
@@ -1,5 +1,6 @@
 {
   "description": "Bootstrap a node with puppet-agent for Linux",
+  "private": true,
   "input_method": "environment",
   "parameters": {
     "master": {
@@ -29,22 +30,6 @@
     "extension_request": {
       "description": "This setting is added to puppet.conf and included in the extension_requests section of csr_attributes.yaml",
       "type": "Optional[Array[Pattern[/\\w+=\\w+/]]]"
-    }
-  },
-  "extensions": {
-    "discovery": {
-      "friendlyName": "Install Puppet agent on Linux",
-      "osFamily": "linux",
-      "puppetInstall": true,
-      "type": ["host"],
-      "parameters": {
-          "master": {
-              "placeholder": "master.company.net"
-          },
-          "cacert_content": {
-              "placeholder": "-----BEGIN CERTIFICATE---- ... -----END CERTIFICATE-----"
-          }
-      }
     }
   }
 }

--- a/tasks/windows.json
+++ b/tasks/windows.json
@@ -1,5 +1,6 @@
 {
   "description": "Bootstrap a node with puppet-agent for Windows",
+  "private": true,
   "input_method": "powershell",
   "parameters": {
     "master": {
@@ -30,21 +31,5 @@
       "description": "This setting is added to puppet.conf and included in the extension_requests section of csr_attributes.yaml",
       "type": "Optional[Array[Pattern[/\\w+=\\w+/]]]"
     }
-  },
-  "extensions": {
-    "discovery": {
-      "friendlyName": "Install Puppet agent on Windows",
-      "osFamily": "Windows",
-      "puppetInstall": true,
-      "type": ["host"],
-      "parameters": {
-          "master": {
-              "placeholder": "master.company.net"
-          },
-          "cacert_content": {
-              "placeholder": "-----BEGIN CERTIFICATE---- ... -----END CERTIFICATE-----"
-          }
-      }
-     }
   }
 }


### PR DESCRIPTION
**Changes**
**1. Move extension metadata:**
windows.json and linux.json are private tasks and won't be surfaced. For this reason the discovery extension metadata should only be added into the init.json file

**2. Make linux.json and windows.json private**
The newly added implementation section will allow the correct implementation to be used for each host (windows.ps1 or linux.sh). With this change we don't need to surface the windows.json and linux.json files so they've been marked private

**3. Add task metadata to init.json**
Add task metadata such as description and all parameters (which are identical in linux.json and windows.json) to the init.json file. This lets us surface this OS agnostic task to the user and have the decision on which implementation to use be abstracted away. 