### PR TITLE
(FM-7919) Ensure TLSv1.2 is used when temporarily disabling ssl

### DIFF
--- a/tasks/windows.ps1
+++ b/tasks/windows.ps1
@@ -53,10 +53,13 @@ function Get-HostName
 function Get-CA($Master)
 {
   $verificationCallback = [Net.ServicePointManager]::ServerCertificateValidationCallback
+  $preservedProtocol = [Net.ServicePointManager]::SecurityProtocol
   try
   {
     # temporarily disable SSL verification while downloading CA
     [Net.ServicePointManager]::ServerCertificateValidationCallback = { $true }
+    # Note: 3072 is the enum value for tls12 to support .NET 4.0
+    [Net.ServicePointManager]::SecurityProtocol = [Net.ServicePointManager]::SecurityProtocol -bor [Net.SecurityProtocolType]3072
     $caUri = "https://${Master}:8140/puppet-ca/v1/certificate/ca"
     Write-Verbose "Downloading root ca cert from $caUri"
     return (New-Object System.Net.WebClient).DownloadString($caUri)
@@ -65,6 +68,7 @@ function Get-CA($Master)
   {
     # restore original chain validation
     [Net.ServicePointManager]::ServerCertificateValidationCallback = $verificationCallback
+    [Net.ServicePointManager]::SecurityProtocol = $preservedProtocol
   }
 }
 


### PR DESCRIPTION
When downloading the CA cert to be used ensure that the protocol is set to TLSv1.2 in order for DownloadString to effectively avoid ssl verification. Note that 3072 is the enum value for tls12 to support .NET 4.0 https://blogs.perficient.com/2016/04/28/tsl-1-2-and-net-support/