### PR TITLE
Enable TLS 1.2 to allow connection to the master and downloading the …

### DIFF
--- a/tasks/windows.ps1
+++ b/tasks/windows.ps1
@@ -188,6 +188,9 @@ function Invoke-SimplifiedInstaller
 
 try
 {
+  # Enable TLS 1.2 to allow connection to the master
+  [Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12
+
   $options = @{
     Master = $Master
     CertName = ($PSBoundParameters['CertName'], (Get-HostName) -ne $null)[0].ToLower()


### PR DESCRIPTION
…installer.

Without this code, the agent installation on Windows fails with the message:

```
Unable to install agent on  with certname : Exception calling \"DownloadString\" with \"1\" argument(s): \"The request was aborted: Could not create SSL/TLS secure channel.\"
```