### PR TITLE
(FM-8112) Ensure TLS set before other actions

### DIFF
--- a/tasks/windows.ps1
+++ b/tasks/windows.ps1
@@ -177,7 +177,6 @@ function Invoke-SimplifiedInstaller
     $ExtraConfig = @{}
   )
 
-  Set-SecurityProtocol
   Out-CA -Content $CACertContent
   $masterCA = New-CertificateFromContent -Content $CACertContent
   $installer = Get-InstallerScriptBlock -Master $Master -RootCertificate $masterCA
@@ -213,6 +212,7 @@ try
     $options.ExtraConfig += @{ 'agent:environment' = "'$Environment'" }
   }
 
+  Set-SecurityProtocol
   $installerOutput = Invoke-SimplifiedInstaller @options
   $jsonOutput = ConvertTo-JsonString $installerOutput
   $jsonSafeConfig = $options.ExtraConfig.GetEnumerator() |


### PR DESCRIPTION
This commit ensures that the `Set-SecurityProtocol` function,
which enables TLS 1.2 for the runspace, is called before any
other functions and in the appropriate scope.