### PR TITLE
(MAINT) Ensure TLS is enabled first on Windows

### DIFF
--- a/tasks/windows.ps1
+++ b/tasks/windows.ps1
@@ -193,6 +193,8 @@ function Invoke-SimplifiedInstaller
 
 try
 {
+  Set-SecurityProtocol
+
   $options = @{
     Master = $Master
     CertName = ($PSBoundParameters['CertName'], (Get-HostName) -ne $null)[0].ToLower()
@@ -212,7 +214,6 @@ try
     $options.ExtraConfig += @{ 'agent:environment' = "'$Environment'" }
   }
 
-  Set-SecurityProtocol
   $installerOutput = Invoke-SimplifiedInstaller @options
   $jsonOutput = ConvertTo-JsonString $installerOutput
   $jsonSafeConfig = $options.ExtraConfig.GetEnumerator() |


### PR DESCRIPTION
Prior to this commit the code to set options would run before
the function to enable TLS connections. As the former relies
on TLS connections this caused errors.

This commit ensures setting TLS is the *first* action taken
after the functions are defined.