### PR TITLE
(MAINT) Update docker image names

### DIFF
--- a/provision.yaml
+++ b/provision.yaml
@@ -1,22 +1,22 @@
 ---
 default:
   provisioner: docker_exp
-  images: ['waffleimage/centos7']
+  images: ['litmusimage/centos:7']
 vagrant:
   provisioner: vagrant
   images: ['centos/7', 'generic/ubuntu1804', 'gusztavvargadr/windows-server']
 travis_deb:
   provisioner: docker
-  images: ['waffleimage/debian8', 'waffleimage/debian9']
+  images: ['litmusimage/debian:8', 'litmusimage/debian:9']
 travis_ub:
   provisioner: docker
-  images: ['waffleimage/ubuntu14.04', 'waffleimage/ubuntu16.04', 'waffleimage/ubuntu18.04']
+  images: ['litmusimage/ubuntu:14.04', 'litmusimage/ubuntu:16.04', 'litmusimage/ubuntu:18.04']
 travis_el6:
   provisioner: docker
-  images: ['waffleimage/centos6']
+  images: ['litmusimage/centos:6']
 travis_el7:
   provisioner: docker
-  images: ['waffleimage/centos7', 'waffleimage/oraclelinux7']
+  images: ['litmusimage/centos:7', 'litmusimage/oraclelinux:7']
 release_checks:
   provisioner: vmpooler
   images: ['redhat-5-x86_64', 'redhat-6-x86_64', 'redhat-7-x86_64', 'redhat-8-x86_64', 'centos-5-x86_64', 'centos-6-x86_64', 'centos-7-x86_64', 'centos-8-x86_64', 'oracle-5-x86_64', 'oracle-6-x86_64', 'oracle-7-x86_64', 'debian-8-x86_64', 'debian-9-x86_64', 'ubuntu-1404-x86_64', 'ubuntu-1604-x86_64', 'ubuntu-1804-x86_64', 'win-2008r2-x86_64', 'win-2012r2-x86_64', 'win-10-pro-x86_64', 'win-2016-x86_64', 'win-2019-x86_64']


### PR DESCRIPTION
Prior to this commit the provision file referenced the old
waffleimage repo for CI docker images to use. This commit
updates the file to point at litmusimage, which is the repo
the latest images are released to.