### PR TITLE
pdksync - Remove EL6 testing from Travis

### DIFF
--- a/.sync.yml
+++ b/.sync.yml
@@ -13,7 +13,6 @@
     provision_list:
       - travis_deb
       - travis_ub
-      - travis_el6
       - travis_el7
       - travis_el8
       - ---travis_el

--- a/.travis.yml
+++ b/.travis.yml
@@ -150,7 +150,7 @@ jobs:
       stage: spec
 branches:
   only:
-    - master
+    - main
     - /^v\d/
     - release
 notifications:

--- a/.travis.yml
+++ b/.travis.yml
@@ -51,17 +51,6 @@ jobs:
       stage: acceptance
     -
       before_script:
-      - "bundle exec rake 'litmus:provision_list[travis_el6]'"
-      - "bundle exec rake 'litmus:install_agent[puppet5]'"
-      - "bundle exec rake litmus:install_module"
-      bundler_args:
-      env: PLATFORMS=travis_el6_puppet5
-      rvm: 2.5.7
-      script: ["travis_wait 45 bundle exec rake litmus:acceptance:parallel"]
-      services: docker
-      stage: acceptance
-    -
-      before_script:
       - "bundle exec rake 'litmus:provision_list[travis_el7]'"
       - "bundle exec rake 'litmus:install_agent[puppet5]'"
       - "bundle exec rake litmus:install_module"
@@ -100,17 +89,6 @@ jobs:
       - "bundle exec rake litmus:install_module"
       bundler_args:
       env: PLATFORMS=travis_ub_puppet6
-      rvm: 2.5.7
-      script: ["travis_wait 45 bundle exec rake litmus:acceptance:parallel"]
-      services: docker
-      stage: acceptance
-    -
-      before_script:
-      - "bundle exec rake 'litmus:provision_list[travis_el6]'"
-      - "bundle exec rake 'litmus:install_agent[puppet6]'"
-      - "bundle exec rake litmus:install_module"
-      bundler_args:
-      env: PLATFORMS=travis_el6_puppet6
       rvm: 2.5.7
       script: ["travis_wait 45 bundle exec rake litmus:acceptance:parallel"]
       services: docker

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -2,7 +2,7 @@
 version: 1.1.x.{build}
 branches:
   only:
-    - master
+    - main
     - release
 skip_commits:
   message: /^\(?doc\)?.*/

--- a/provision.yaml
+++ b/provision.yaml
@@ -11,9 +11,6 @@ travis_deb:
 travis_ub:
   provisioner: docker
   images: ['litmusimage/ubuntu:14.04', 'litmusimage/ubuntu:16.04', 'litmusimage/ubuntu:18.04']
-travis_el6:
-  provisioner: docker
-  images: ['litmusimage/centos:6']
 travis_el7:
   provisioner: docker
   images: ['litmusimage/centos:7', 'litmusimage/oraclelinux:7']


### PR DESCRIPTION
Remove EL6 testing from Travis
pdk version: `1.18.0` 
