### PR TITLE
[ISSUE-80] Update the README to improve the instructions for use of ex…

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,11 +62,11 @@ You can also run tasks in the PE console. See PE task documentation for complete
 
 #### Example: Specify a custom_attribute
 
-Optionally to install the Puppet agent and adding a setting to puppet.conf and including it in the custom_attributes section of csr_attributes.yaml: `bolt task run bootstrap master=<master's fqdn> custom_attribute=key=value --nodes x,y,z --modulepath /path/to/modules`
+Optionally to install the Puppet agent and adding a setting to puppet.conf and including it in the custom_attributes section of csr_attributes.yaml: `bolt task run bootstrap master=<master's fqdn> custom_attribute='["<key>=<value>"]' --nodes x,y,z --modulepath /path/to/modules`
 
 #### Example: Specify a extension_request
 
-Optionally to install the Puppet agent and adding a setting to puppet.conf and including it in the extension_requests section of csr_attributes.yaml: `bolt task run bootstrap master=<master's fqdn> extension_request=key=value --nodes x,y,z --modulepath /path/to/modules`
+Optionally to install the Puppet agent and adding a setting to puppet.conf and including it in the extension_requests section of csr_attributes.yaml: `bolt task run bootstrap master=<master's fqdn> extension_request=key='["<extension>=<value>"]' --nodes x,y,z --modulepath /path/to/modules`
 
 ## Reference
 


### PR DESCRIPTION
…tension_requests and custom_attributes.

The examples were unclear on formatting the command to include extension_requests and custom_attributes, leading to some frustration having to identify the proper format.
The change specifies the format for adding the extensions/attributes to the task run command to make the documentation more accessible.