### PR TITLE
Expand permitted custom_attribute and extension_request values

### DIFF
--- a/REFERENCE.md
+++ b/REFERENCE.md
@@ -58,13 +58,13 @@ The DNS alt names with which the agent certificate should be generated
 
 ##### `custom_attribute`
 
-Data type: `Optional[Array[Pattern[/\w+=\w+/]]]`
+Data type: `Optional[Array[Pattern[/[\w\.]+=[\w\.]+/]]]`
 
 This setting is added to puppet.conf and included in the custom_attributes section of csr_attributes.yaml
 
 ##### `extension_request`
 
-Data type: `Optional[Array[Pattern[/\w+=\w+/]]]`
+Data type: `Optional[Array[Pattern[/\w+=[\w\.]+/]]]`
 
 This setting is added to puppet.conf and included in the extension_requests section of csr_attributes.yaml
 
@@ -120,13 +120,13 @@ The DNS alt names with which the agent certificate should be generated
 
 ##### `custom_attribute`
 
-Data type: `Optional[Array[Pattern[/\w+=\w+/]]]`
+Data type: `Optional[Array[Pattern[/[\w\.]+=[\w\.]+/]]]`
 
 This setting is added to puppet.conf and included in the custom_attributes section of csr_attributes.yaml
 
 ##### `extension_request`
 
-Data type: `Optional[Array[Pattern[/\w+=\w+/]]]`
+Data type: `Optional[Array[Pattern[/\w+=[\w\.]+/]]]`
 
 This setting is added to puppet.conf and included in the extension_requests section of csr_attributes.yaml
 
@@ -182,13 +182,13 @@ The DNS alt names with which the agent certificate should be generated
 
 ##### `custom_attribute`
 
-Data type: `Optional[Array[Pattern[/\w+=\w+/]]]`
+Data type: `Optional[Array[Pattern[/[\w\.]+=[\w\.]+/]]]`
 
 This setting is added to puppet.conf and included in the custom_attributes section of csr_attributes.yaml
 
 ##### `extension_request`
 
-Data type: `Optional[Array[Pattern[/\w+=\w+/]]]`
+Data type: `Optional[Array[Pattern[/\w+=[\w\.]+/]]]`
 
 This setting is added to puppet.conf and included in the extension_requests section of csr_attributes.yaml
 

--- a/tasks/init.json
+++ b/tasks/init.json
@@ -28,11 +28,11 @@
     },
     "custom_attribute": {
       "description": "This setting is added to puppet.conf and included in the custom_attributes section of csr_attributes.yaml",
-      "type": "Optional[Array[Pattern[/\\w+=\\w+/]]]"
+      "type": "Optional[Array[Pattern[/[\\w\\.]+=[\\w\\.]+/]]]"
     },
     "extension_request": {
       "description": "This setting is added to puppet.conf and included in the extension_requests section of csr_attributes.yaml",
-      "type": "Optional[Array[Pattern[/\\w+=\\w+/]]]"
+      "type": "Optional[Array[Pattern[/\\w+=[\\w\\.]+/]]]"
     },
     "puppet_conf_settings": {
       "description": "Puppet conf settings. See https://www.puppet.com/docs/pe/2021.7/installing_nix_and_windows_agents_using_an_install_script.html#customize-install-script for usage instructions",

--- a/tasks/linux.json
+++ b/tasks/linux.json
@@ -29,11 +29,11 @@
     },
     "custom_attribute": {
       "description": "This setting is added to puppet.conf and included in the custom_attributes section of csr_attributes.yaml",
-      "type": "Optional[Array[Pattern[/\\w+=\\w+/]]]"
+      "type": "Optional[Array[Pattern[/[\\w\\.]+=[\\w\\.]+/]]]"
     },
     "extension_request": {
       "description": "This setting is added to puppet.conf and included in the extension_requests section of csr_attributes.yaml",
-      "type": "Optional[Array[Pattern[/\\w+=\\w+/]]]"
+      "type": "Optional[Array[Pattern[/\\w+=[\\w\\.]+/]]]"
     },
     "puppet_conf_settings": {
       "description": "Puppet conf settings. See https://www.puppet.com/docs/pe/2021.7/installing_nix_and_windows_agents_using_an_install_script.html#customize-install-script for usage instructions",

--- a/tasks/windows.json
+++ b/tasks/windows.json
@@ -29,11 +29,11 @@
     },
     "custom_attribute": {
       "description": "This setting is added to puppet.conf and included in the custom_attributes section of csr_attributes.yaml",
-      "type": "Optional[Array[Pattern[/\\w+=\\w+/]]]"
+      "type": "Optional[Array[Pattern[/[\\w\\.]+=[\\w\\.]+/]]]"
     },
     "extension_request": {
       "description": "This setting is added to puppet.conf and included in the extension_requests section of csr_attributes.yaml",
-      "type": "Optional[Array[Pattern[/\\w+=\\w+/]]]"
+      "type": "Optional[Array[Pattern[/\\w+=[\\w\\.]+/]]]"
     },
     "puppet_conf_settings": {
       "description": "Puppet conf settings. See https://www.puppet.com/docs/pe/2021.7/installing_nix_and_windows_agents_using_an_install_script.html#customize-install-script for usage instructions",

--- a/tasks/windows.ps1
+++ b/tasks/windows.ps1
@@ -36,12 +36,12 @@ Param(
   $Set_Noop,
 
   [Parameter(Mandatory = $False)]
-  [ValidateScript({ $_ -match '\w+=\w+' })]
+  [ValidateScript({ $_ -match '[\w\.]+=[\w\.]+' })]
   [String[]]
   $Custom_Attribute,
 
   [Parameter(Mandatory = $False)]
-  [ValidateScript({ $_ -match '\w+=\w+' })]
+  [ValidateScript({ $_ -match '\w+=[\w\.]+' })]
   [String[]]
   $Extension_Request,
 


### PR DESCRIPTION
Allow `custom_attribute` as a key to accept OIDs.
Allow `.` to be used in the values of both `custom_attribute` and `extension_request`.

By allowing OIDs in the `custom_attribute` key allows users to set `1.2.840.113549.1.9.7` for use with [autosign](https://help.puppet.com/core//current/Content/PuppetCore/config_file_csr_attributes.htm?Highlight=challengePassword)
Updating the accepted value for `custom_attribute` and `extension_request` allows for the use of more autosign tools like [danieldreier/autosign](https://forge.puppet.com/modules/danieldreier/autosign/readme) that uses JWT.